### PR TITLE
fix: added lambda logging permissions

### DIFF
--- a/infra/modules/lambda/iam.tf
+++ b/infra/modules/lambda/iam.tf
@@ -14,3 +14,31 @@ resource "aws_iam_role" "lambda_role" {
   name               = "${var.project}-${var.env}-lambda-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
 }
+
+resource "aws_iam_policy" "lambda_logging" {
+  name        = "lambda_logging"
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.lambda_role.arn
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}

--- a/infra/modules/lambda/lambda.tf
+++ b/infra/modules/lambda/lambda.tf
@@ -37,31 +37,3 @@ resource "aws_cloudwatch_log_group" "convert_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.board_notification.function_name}"
   retention_in_days = 3
 }
-
-resource "aws_iam_policy" "lambda_logging" {
-  name        = "lambda_logging"
-  path        = "/"
-  description = "IAM policy for logging from a lambda"
-
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": "arn:aws:logs:*:*:*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_logs" {
-  role       = aws_iam_role.lambda_role.arn
-  policy_arn = aws_iam_policy.lambda_logging.arn
-}

--- a/infra/modules/lambda/lambda.tf
+++ b/infra/modules/lambda/lambda.tf
@@ -37,3 +37,31 @@ resource "aws_cloudwatch_log_group" "convert_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.board_notification.function_name}"
   retention_in_days = 3
 }
+
+resource "aws_iam_policy" "lambda_logging" {
+  name        = "lambda_logging"
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.lambda_role.arn
+  policy_arn = aws_iam_policy.lambda_logging.arn
+}


### PR DESCRIPTION
this pr aims at adding log permissions to the lamda
resolves: https://github.com/nearform/github-board-slack-notifications/issues/113