### PR TITLE
fix: fixed formatting when a field is undefined

### DIFF
--- a/config/notification-config.json
+++ b/config/notification-config.json
@@ -1,27 +1,27 @@
 {
     "actions": {
         "created": {
-            "message": "💡 <{authorUrl}| {authorName}> has a created a {content_type} titled _<{itemUrl}| #{itemNumber} {title}>_ in <{projectUrl}| {projectName}> ➕️"
+            "message": "💡 <{authorUrl}{authorName}> has a created a {content_type} titled _<{itemUrl}{itemNumber}{title}>_ in <{projectUrl}{projectName}> ➕️"
         },
         "deleted": {
-            "message": "💡 {content_type} _<{itemUrl}| #{itemNumber} {title}>_ has been deleted from <{projectUrl}| {projectName}> ❌"
+            "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been deleted from <{projectUrl}{projectName}> ❌"
         },
         "converted": {
-            "message": "💡 {content_type} _<{itemUrl}| #{itemNumber} {title}>_ has been converted 🔄",
+            "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been converted 🔄",
             "changes": {
                 "Issue": {
-                    "message": "💡 <{authorUrl}| {authorName}> has a created a {content_type} titled _<{itemUrl}| #{itemNumber} {title})}>_ in <{projectUrl}| {projectName}> 🚩"
+                    "message": "💡 <{authorUrl}{authorName}> has a created a {content_type} titled _<{itemUrl}{itemNumber}{title}>_ in <{projectUrl}{projectName}> 🚩"
                 }
             }
         },
         "edited": {
-            "message": "💡 {content_type} _<{itemUrl}| #{itemNumber} {title}>_ has been edited 📝",
+            "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been edited 📝",
             "changes": {
                 "single_select": {
-                    "message": "💡 {content_type} _<{itemUrl}| #{itemNumber} {title}>_ {changed_field} has been changed to {updated_value} 📌"
+                    "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ {changed_field} has been changed to {updated_value} 📌"
                 },
                 "assignees": {
-                    "message": "💡 {content_type} _<{itemUrl}| #{itemNumber} {title}>_ has been assigned to {assignees} 👤"
+                    "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been assigned to {assignees} 👤"
                 }
             }
         }

--- a/config/notification-config.json
+++ b/config/notification-config.json
@@ -1,27 +1,27 @@
 {
     "actions": {
         "created": {
-            "message": "💡 <{authorUrl}{authorName}> has a created a {content_type} titled _<{itemUrl}{itemNumber}{title}>_ in <{projectUrl}{projectName}> ➕️"
+            "message": "➕️ <{authorUrl}{authorName}> has created a {content_type} titled _<{itemUrl}{itemNumber}{title}>_ in <{projectUrl}{projectName}>"
         },
         "deleted": {
-            "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been deleted from <{projectUrl}{projectName}> ❌"
+            "message": "❌ {content_type} _<{itemUrl}{itemNumber}{title}>_ has been deleted from <{projectUrl}{projectName}>"
         },
         "converted": {
-            "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been converted 🔄",
+            "message": "🔄 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been converted",
             "changes": {
                 "Issue": {
-                    "message": "💡 <{authorUrl}{authorName}> has a created a {content_type} titled _<{itemUrl}{itemNumber}{title}>_ in <{projectUrl}{projectName}> 🚩"
+                    "message": "🚩 <{authorUrl}{authorName}> has created a {content_type} titled _<{itemUrl}{itemNumber}{title}>_ in <{projectUrl}{projectName}>"
                 }
             }
         },
         "edited": {
-            "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been edited 📝",
+            "message": "📝 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been edited",
             "changes": {
                 "single_select": {
-                    "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ {changed_field} has been changed to {updated_value} 📌"
+                    "message": "📌 {content_type} _<{itemUrl}{itemNumber}{title}>_ {changed_field} has been changed to {updated_value}"
                 },
                 "assignees": {
-                    "message": "💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been assigned to {assignees} 👤"
+                    "message": "👤 {content_type} _<{itemUrl}{itemNumber}{title}>_ has been assigned to {assignees}"
                 }
             }
         }

--- a/src/messages.js
+++ b/src/messages.js
@@ -52,17 +52,27 @@ export function formatMessage({ content_type, node, message, extra }) {
 function getKeysFromNode({ node }) {
   const { creator, project, content, fieldValueByName } = node
   return {
-    authorUrl: content?.author?.url ? content.author.url : creator?.url,
+    authorUrl: addPipeToUrl(
+      content?.author?.url ? content.author.url : creator?.url
+    ),
     number: project.number,
     authorName: content?.author?.name ? content.author.name : creator?.login,
-    projectUrl: project.url,
-    itemUrl: content?.url,
+    projectUrl: addPipeToUrl(project.url),
+    itemUrl: addPipeToUrl(content?.url),
     updated_value: fieldValueByName?.name,
-    itemNumber: content?.number,
+    itemNumber: addHashtagToNumber(content?.number),
     projectName: project.title,
     title: escapeMarkdown(content?.title),
     assignees: parseAssignees(content?.assignees),
   }
+}
+
+function addPipeToUrl(url) {
+  return url ? `${url}| ` : ''
+}
+
+function addHashtagToNumber(number) {
+  return number ? `#${number} ` : ''
 }
 
 function replaceKeys(message, valuesToReplace) {

--- a/src/messages.js
+++ b/src/messages.js
@@ -52,11 +52,9 @@ export function formatMessage({ content_type, node, message, extra }) {
 function getKeysFromNode({ node }) {
   const { creator, project, content, fieldValueByName } = node
   return {
-    authorUrl: addPipeToUrl(
-      content?.author?.url ? content.author.url : creator?.url
-    ),
+    authorUrl: addPipeToUrl(content?.author?.url || creator?.url),
     number: project.number,
-    authorName: content?.author?.name ? content.author.name : creator?.login,
+    authorName: content?.author?.name || creator?.login,
     projectUrl: addPipeToUrl(project.url),
     itemUrl: addPipeToUrl(content?.url),
     updated_value: fieldValueByName?.name,

--- a/src/messages.js
+++ b/src/messages.js
@@ -103,14 +103,6 @@ export const markdownEscapes = [
     replacement: '\\)',
   },
   {
-    regex: /\[/g,
-    replacement: '\\[',
-  },
-  {
-    regex: /\]/g,
-    replacement: '\\]',
-  },
-  {
     regex: /</g,
     replacement: '&lt;',
   },

--- a/test/slackbot.test.js
+++ b/test/slackbot.test.js
@@ -110,7 +110,7 @@ test('test slackbot', async t => {
   })
 
   t.test('format message fills authoUrl correctly', async t => {
-    const message = '{authorUrl} {authorName}'
+    const message = '{authorUrl}{authorName}'
     const authorUrl = 'https://api.github.com/users/some-author'
     const authorName = 'some-author'
     const creatorUrl = 'https://api.github.com/users/some-creator'
@@ -127,7 +127,27 @@ test('test slackbot', async t => {
     node.content.author = {}
     const formattedMessageWithCreator = formatMessage({ message, node })
 
-    t.equal(`${authorUrl} ${authorName}`, formattedMessageWithAuthor)
-    t.equal(`${creatorUrl} ${creatorName}`, formattedMessageWithCreator)
+    t.equal(`${authorUrl}| ${authorName}`, formattedMessageWithAuthor)
+    t.equal(`${creatorUrl}| ${creatorName}`, formattedMessageWithCreator)
+  })
+
+  t.test('undefined parameters are ignored', async t => {
+    const content_type = 'DraftIssue'
+    const title = 'random-title'
+    const message =
+      '💡 {content_type} _<{itemUrl}{itemNumber}{title}>_ Status has been changed to Done 📌'
+    const expectedResult = `💡 ${content_type} _<${title}>_ Status has been changed to Done 📌`
+    const node = {
+      content: {
+        title,
+      },
+      project: {},
+    }
+    const formattedMessage = formatMessage({
+      content_type,
+      message,
+      node,
+    })
+    t.equal(expectedResult, formattedMessage)
   })
 })


### PR DESCRIPTION
resolves: https://github.com/nearform/github-board-slack-notifications/issues/124
the aim is to prevent undefined fields from appearing in the message