### PR TITLE
fix: update terraform provider version

### DIFF
--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.25"
+      version = "~> 4.55"
     }
   }
 


### PR DESCRIPTION
The current provider version do not have the node 18 runtime.