### PR TITLE
feat: unfurl links

### DIFF
--- a/src/slackbot.js
+++ b/src/slackbot.js
@@ -18,6 +18,7 @@ async function sendMessage({ app, text, channels }) {
             text: {
               type: 'mrkdwn',
               text,
+              unfurl_links: false,
             },
           },
         ],


### PR DESCRIPTION
This pr removes the link preview from the Slack message